### PR TITLE
Fixed issue #1 : clean up empty resource directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>Jetty :: Jetty JSPC Maven Plugin</name>
 
 	<properties>
-		<jetty.version>9.1.3.v20140225</jetty.version>
+		<jetty.version>9.1.4.v20140401</jetty.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
+++ b/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
@@ -25,7 +25,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+import java.util.Set;;
 import java.util.regex.Pattern;
 
 import org.apache.jasper.JspC;
@@ -235,6 +235,7 @@ public class JspcMojo extends AbstractMojo {
 			compile();
 			cleanupSrcs();
 			deleteCompiledJspsFromTarget();
+			cleanupEmptyResourceFolder();
 			mergeWebXml();
 		} catch (Exception e) {
 			throw new MojoExecutionException("Failure processing jsps", e);
@@ -339,6 +340,35 @@ public class JspcMojo extends AbstractMojo {
 			}
 		} else {
 			getLog().info(">>>>>>>>>> No jsp files cleaned, it is recommended these do not get bundled with your web fragment to avoid JRE issues. <<<<<<<<<<<<");
+		}
+	}
+
+	protected void cleanupEmptyResourceFolder() {
+		try {
+			doCleanUpEmptyResourceFolder();
+		} catch (IOException ioEx) {
+			getLog().warn(String.format("Cannot cleanup the empty resource folder because of %s", ioEx.getMessage()));
+		}
+	}
+
+	/**
+	 * Cleanup empty resource directory
+	 *
+	 * @throws IOException
+	 */
+	private void doCleanUpEmptyResourceFolder() throws IOException {
+		if (deleteJspPath != null) {
+			StringBuilder resourcePath = new StringBuilder();
+			resourcePath.append(project.getBuild().getOutputDirectory()).append(File.separator).append(deleteJspPath);
+			List<String> childDirectoryList = FileUtils.getDirectoryNames(new File(resourcePath.toString()), "*", null, true);
+			for (String directory : childDirectoryList) {
+				File folder = new File(directory);
+				List<File> fileList = FileUtils.getFiles(folder, "**", null, false);
+				if (folder.exists() && fileList.size() == 0) {
+					getLog().info("Cleaned directory " + folder.getPath());
+					FileUtils.deleteDirectory(folder);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Able to delete the empty resource directory under META-INF/resources/, but cannot delete empty sub-directory under META-INF/resources/angular/controllers/, because FileUtils.getDirectoryName does not return them if there is no files under. And I also really don't want to loop them recursively.
