### PR TITLE
Documentation fix w/ Dependency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,20 @@ if you rely on your jsps existing.
   <groupId>com.bluetrainsoftware.bathe.web</groupId>
   <artifactId>bathe-jetty-jspc-maven-plugin</artifactId>
   <version>1.3</version>
+  <dependencies>
+	  <dependency>
+		  <groupId>org.eclipse.jetty</groupId>
+		  <artifactId>jetty-util</artifactId>
+		  <version>${jetty.version}</version>
+		  <scope>provided</scope>
+	  </dependency>
+	  <dependency>
+		  <groupId>org.eclipse.jetty</groupId>
+		  <artifactId>jetty-jsp</artifactId>
+		  <version>${jetty-jsp.version}</version>
+		  <scope>provided</scope>
+	  </dependency>
+  </dependencies>
   <executions>
     <execution>
         <id>war-compile-jsp</id>
@@ -20,20 +34,6 @@ if you rely on your jsps existing.
           <goal>jspc</goal>
         </goals>
         <phase>compile</phase>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jsp</artifactId>
-                <version>${jetty.version}</version>
-                <scope>provided</scope>
-            </dependency>
-        </dependencies>
         <configuration>
             <compilerSourceVM>1.8</compilerSourceVM>
             <compilerTargetVM>1.8</compilerTargetVM>
@@ -45,7 +45,7 @@ if you rely on your jsps existing.
 ----
 
 It is a bit icky because it dictates the version of Jetty and requires re-release for a new version. Generally that
-isn't too much of a problem as  the jsp layer doesn't change between versions of Jetty.
+isn't too much of a problem as the jsp layer doesn't change between versions of Jetty.
 
 == Changelog
 


### PR DESCRIPTION
This change moves the `dependencies` into the
correct place in the plugin declaration.  Also the
"jetty-jsp" appears to be independent of the Jetty
version so to highlight this, a different property is
used to avoid confusion.